### PR TITLE
[Icon] Fix "th.large" conflict with "th" in "large" size.

### DIFF
--- a/static/corrections.json
+++ b/static/corrections.json
@@ -64,5 +64,9 @@
   "the-red-yeti": {
     "fuiName": "redyeti",
     "className": "redyeti"
+  },
+  "th-large": {
+    "fuiName": "th larger",
+    "className": "th.larger"
   }
 }


### PR DESCRIPTION
# Description
:boom: Breaking Change

Rename `th large icon` to `th larger icon` so we can ...
* distinguish `large th icon` (large 9 thumbnails) with `th large(r) icon` (medium 4 thumbnails)
* require no CSS workaround for `mini th large(r) icon` or alike.

# Addresses
https://github.com/Semantic-Org/Semantic-UI/issues/6336
https://github.com/Semantic-Org/Semantic-UI/issues/6499

# Note
I think it is better to rename `th large` instead of  my initial workaround (https://github.com/fomantic/Fomantic-UI/pull/213) that can only address 1 issue.