### PR TITLE
fix(alias): Convert the two-words aliases into one-word aliases

### DIFF
--- a/lib/static/aliases.json
+++ b/lib/static/aliases.json
@@ -1015,9 +1015,9 @@
         "type": "solid"
     },
     {
-        "rawName": "line-graph",
-        "name": "line graph",
-        "className": "line.graph",
+        "rawName": "linegraph",
+        "name": "linegraph",
+        "className": "linegraph",
         "unicode": "\\f201",
         "type": "solid"
     },

--- a/lib/static/corrections.json
+++ b/lib/static/corrections.json
@@ -57,5 +57,9 @@
     "the-red-yeti": {
         "name": "redyeti",
         "className": "redyeti"
+    },
+    "chart-line": {
+        "name": "chartline",
+        "className": "chartline"
     }
 }

--- a/src/static/aliases.json
+++ b/src/static/aliases.json
@@ -1015,9 +1015,9 @@
     "type": "solid"
   },
   {
-    "rawName": "line-graph",
-    "name": "line graph",
-    "className": "line.graph",
+    "rawName": "linegraph",
+    "name": "linegraph",
+    "className": "linegraph",
     "unicode": "\\f201",
     "type": "solid"
   },

--- a/src/static/corrections.json
+++ b/src/static/corrections.json
@@ -57,5 +57,9 @@
   "the-red-yeti": {
     "name": "redyeti",
     "className": "redyeti"
-  }
+  },
+  "chart-line": {
+    "name": "chartline",
+    "className": "chartline"
+}
 }


### PR DESCRIPTION
Convert the two-words aliases `line graph` into `linegraph` which conflicts with other FUI components which uses the CSS class name `line`.

## Closes
https://github.com/fomantic/Fomantic-UI/issues/1619