### PR TITLE
feat(template): use double columns for pseudo elements

### DIFF
--- a/src/templates/icon.overrides.liquid
+++ b/src/templates/icon.overrides.liquid
@@ -33,13 +33,13 @@ Icons are order A-Z in their group, Solid, Outline, Thin (Pro only) and Brand
 *******************************/
 & when(@variationIconDeprecated) {
 /* Deprecated *In/Out Naming Conflict) */
-i.icon.linkedin.in:before { content: "\f0e1"; }
-i.icon.zoom.in:before { content: "\f00e"; }
-i.icon.zoom.out:before { content: "\f010"; }
-i.icon.sign.in:before { content: "\f2f6"; }
-i.icon.in.cart:before { content: "\f218"; }
-i.icon.log.out:before { content: "\f2f5"; }
-i.icon.sign.out:before { content: "\f2f5"; }
+i.icon.linkedin.in::before { content: "\f0e1"; }
+i.icon.zoom.in::before { content: "\f00e"; }
+i.icon.zoom.out::before { content: "\f010"; }
+i.icon.sign.in::before { content: "\f2f6"; }
+i.icon.in.cart::before { content: "\f218"; }
+i.icon.log.out::before { content: "\f2f5"; }
+i.icon.sign.out::before { content: "\f2f5"; }
 }
 
 {% if icons.solid.icons.length > 0 -%}
@@ -50,14 +50,14 @@ i.icon.sign.out:before { content: "\f2f5"; }
 
 /* Icons */
 {% for icon in icons.solid.icons -%}
-  i.icon.{{ icon.className }}:before { content: "{{ icon.unicode }}"; }
+  i.icon.{{ icon.className }}::before { content: "{{ icon.unicode }}"; }
 {% endfor %}
 }
 {% if icons.solid.aliases.length > 0 -%}
 & when(@variationIconAliases) {
 /* Aliases */
 {% for icon in icons.solid.aliases -%}
-  i.icon.{{ icon.className }}:before { content: "{{ icon.unicode }}"; }
+  i.icon.{{ icon.className }}::before { content: "{{ icon.unicode }}"; }
 {% endfor %}
 }
 {%- endif %}{%- endif %}
@@ -89,14 +89,14 @@ i.icon.sign.out:before { content: "\f2f5"; }
 
   /* Icons */
   {% for icon in icons.outline.icons -%}
-    i.icon.{{ icon.className }}:before { content: "{{ icon.unicode }}"; }
+    i.icon.{{ icon.className }}::before { content: "{{ icon.unicode }}"; }
   {% endfor %}
 
   {% if icons.outline.aliases.length > 0 -%}
   & when(@variationIconAliases) {
   /* Aliases */
   {% for icon in icons.outline.aliases -%}
-    i.icon.{{ icon.className }}:before { content: "{{ icon.unicode }}"; }
+    i.icon.{{ icon.className }}::before { content: "{{ icon.unicode }}"; }
   {% endfor %}
   }
   {%- endif %}
@@ -130,14 +130,14 @@ i.icon.sign.out:before { content: "\f2f5"; }
 
   /* Icons */
   {% for icon in icons.thin.icons -%}
-    i.icon.{{ icon.className }}:before { content: "{{ icon.unicode }}"; }
+    i.icon.{{ icon.className }}::before { content: "{{ icon.unicode }}"; }
   {% endfor %}
 
   {% if icons.thin.aliases.length > 0 -%}
   & when(@variationIconAliases) {
   /* Aliases */
   {% for icon in icons.thin.aliases -%}
-    i.icon.{{ icon.className }}:before { content: "{{ icon.unicode }}"; }
+    i.icon.{{ icon.className }}::before { content: "{{ icon.unicode }}"; }
   {% endfor %}
   }
   {%- endif %}
@@ -167,14 +167,14 @@ i.icon.sign.out:before { content: "\f2f5"; }
 
   /* Icons */
   {% for icon in icons.brand.icons -%}
-    i.icon.{{ icon.className }}:before { content: "{{ icon.unicode }}"; font-family: @brandFontName; }
+    i.icon.{{ icon.className }}::before { content: "{{ icon.unicode }}"; font-family: @brandFontName; }
   {% endfor %}
 
   {% if icons.brand.aliases.length > 0 -%}
   & when(@variationIconAliases) {
   /* Aliases */
   {% for icon in icons.brand.aliases -%}
-    i.icon.{{ icon.className }}:before { content: "{{ icon.unicode }}"; font-family: @brandFontName; }
+    i.icon.{{ icon.className }}::before { content: "{{ icon.unicode }}"; font-family: @brandFontName; }
   {% endfor %}
   }
   {%- endif %}


### PR DESCRIPTION
## Description
Use double colons for psuedo elements as we do not support IE < 9 anymore

Initiated by https://github.com/fomantic/Fomantic-UI/pull/2304 where i stumpled upon the tons of suggested changes in the generated icon.overrides file