### PR TITLE
fix(icon): fix lighthouse warning

### DIFF
--- a/src/templates/icon.variables.liquid
+++ b/src/templates/icon.variables.liquid
@@ -50,6 +50,7 @@ Icons are order A-Z in their group, Solid, Outline, Thin (Pro only) and Brand
     if(@supportIE, e(',') url("@{fontPath}/@{fontName}.woff") format('woff'));
     font-style     : normal;
     font-weight    : @normal;
+    font-display   : block;
     font-variant   : normal;
     text-decoration: inherit;
     text-transform : none;
@@ -62,6 +63,7 @@ Icons are order A-Z in their group, Solid, Outline, Thin (Pro only) and Brand
     if(@supportIE, e(',') url("@{fontPath}/@{outlineFontName}.woff") format('woff'));
     font-style     : normal;
     font-weight    : @normal;
+    font-display   : block;
     font-variant   : normal;
     text-decoration: inherit;
     text-transform : none;
@@ -74,6 +76,7 @@ Icons are order A-Z in their group, Solid, Outline, Thin (Pro only) and Brand
     if(@supportIE, e(',') url("@{fontPath}/@{thinFontName}.woff") format('woff'));
     font-style     : normal;
     font-weight    : @normal;
+    font-display   : block;
     font-variant   : normal;
     text-decoration: inherit;
     text-transform : none;
@@ -86,6 +89,7 @@ Icons are order A-Z in their group, Solid, Outline, Thin (Pro only) and Brand
     if(@supportIE, e(',') url("@{fontPath}/@{brandFontName}.woff") format('woff'));
     font-style     : normal;
     font-weight    : @normal;
+    font-display   : block;
     font-variant   : normal;
     text-decoration: inherit;
     text-transform : none;


### PR DESCRIPTION
## Description
the icon fonts need font-display to eliminate lighthouse warning in devtools
Fontaweseome did this themselves by https://github.com/FortAwesome/wordpress-fontawesome/pull/110

## Related FUI PR
https://github.com/fomantic/Fomantic-UI/pull/2519
