### PR TITLE
feat(chore): only copy relevant woff files from fa package

### DIFF
--- a/lib/tasks/BuildDist.js
+++ b/lib/tasks/BuildDist.js
@@ -85,15 +85,21 @@ function run(results, parseResults) {
                 fse.mkdirp(distPath)
                     .then(function () {
                     files.forEach(function (file) {
-                        var filenameSplit = file.split('.');
-                        var newFileName = "".concat(parseResults.fontFileNames[filenameSplit[0]], ".").concat(filenameSplit[1]);
-                        var assetFilePath = (0, path_1.resolve)(parseResults.fontAssetsDirectory, file);
-                        var assetDistPath = (0, path_1.resolve)(distPath, newFileName);
-                        fse.copyFile(assetFilePath, assetDistPath)
-                            .then(function () {
+                        var _a = file.split('.'), fileName = _a[0], fileExtension = _a[1];
+                        var newFileName = parseResults.fontFileNames[fileName];
+                        if (newFileName && fileExtension && fileExtension.toLowerCase().startsWith('woff')) {
+                            newFileName += ".".concat(fileExtension);
+                            var assetFilePath = (0, path_1.resolve)(parseResults.fontAssetsDirectory, file);
+                            var assetDistPath = (0, path_1.resolve)(distPath, newFileName);
+                            fse.copyFile(assetFilePath, assetDistPath)
+                                .then(function () {
+                                copied();
+                            })
+                                .catch(rejectAssetCopy);
+                        }
+                        else {
                             copied();
-                        })
-                            .catch(rejectAssetCopy);
+                        }
                     });
                 })
                     .catch(rejectAssetCopy);

--- a/lib/util/Converter.js
+++ b/lib/util/Converter.js
@@ -27,7 +27,7 @@ var Converter = /** @class */ (function () {
             .replace(/\s/g, '.')
             .split('.')
             .map(function (entity) { return (Converter.NUMERIC_ONLY.test(entity)
-            ? (0, num_words_1.default)(entity)
+            ? (0, num_words_1.default)(parseInt(entity, 10))
             : entity); })
             .join('.');
     };

--- a/src/tasks/BuildDist.ts
+++ b/src/tasks/BuildDist.ts
@@ -67,18 +67,23 @@ export default function run(results: PromptResults, parseResults: ParseResults):
           fse.mkdirp(distPath)
             .then(() => {
               files.forEach((file) => {
-                const filenameSplit = file.split('.');
-                const newFileName = `${parseResults.fontFileNames[filenameSplit[0]]}.${filenameSplit[1]}`;
-                const assetFilePath = resolvePath(
-                  parseResults.fontAssetsDirectory,
-                  file,
-                );
-                const assetDistPath = resolvePath(distPath, newFileName);
-                fse.copyFile(assetFilePath, assetDistPath)
-                  .then(() => {
-                    copied();
-                  })
-                  .catch(rejectAssetCopy);
+                const [fileName, fileExtension] = file.split('.');
+                let newFileName = parseResults.fontFileNames[fileName];
+                if (newFileName && fileExtension && fileExtension.toLowerCase().startsWith('woff')) {
+                  newFileName += `.${fileExtension}`;
+                  const assetFilePath = resolvePath(
+                    parseResults.fontAssetsDirectory,
+                    file,
+                  );
+                  const assetDistPath = resolvePath(distPath, newFileName);
+                  fse.copyFile(assetFilePath, assetDistPath)
+                    .then(() => {
+                      copied();
+                    })
+                    .catch(rejectAssetCopy);
+                } else {
+                  copied();
+                }
               });
             })
             .catch(rejectAssetCopy);

--- a/src/util/Converter.ts
+++ b/src/util/Converter.ts
@@ -23,7 +23,7 @@ export default class Converter {
       .replace(/\s/g, '.')
       .split('.')
       .map((entity: string) => (Converter.NUMERIC_ONLY.test(entity)
-        ? numWords(entity)
+        ? numWords(parseInt(entity, 10))
         : entity))
       .join('.');
   }


### PR DESCRIPTION
## Description
The script basically copies all existing font files from within the "webfont" folder out of the downloaded fa zip package.
However, FUI by default only uses the woff(2) files since 2.9.0, so this PR now limits the assets copy to woff(2) files and also makes sure irrelevant files (for example fa 6 has a "fa-v4compatibility.woff/ttf" file included) are also not copied

## Fixes
https://github.com/fomantic/create-fomantic-icons/issues/308#issuecomment-1698267576